### PR TITLE
Add \text to word equation

### DIFF
--- a/6-waves.tex
+++ b/6-waves.tex
@@ -34,7 +34,7 @@ This equation follows from the definition of the frequency and time period of a 
 
 \spec{recall and use the wave equation $v=f\lambda$}
 
-$$speed = \frac{distance travelled}{time taken}$$
+$$\text{speed} = \frac{\text{distance travelled}}{\text{time taken}}$$
 
 For a wave, the distance travelled in one time period, $T$, is the wavelength, $\lambda$. Therefore we can write
 


### PR DESCRIPTION
The document displayed "speed", "distance travelled", and "time taken" hitherto as italicised sequences of variables, rather than words, and omitting the space. This pull request fixes this, and thus brings the formatting into line with standard practice and the rest of the document.

-- Benedict Randall Shaw