### PR TITLE
Fix broken \caption

### DIFF
--- a/7-superposition.tex
+++ b/7-superposition.tex
@@ -114,7 +114,7 @@ If more than two waves superpose, the resultant wave can get very complicated! T
 \begin{figure}[h!]
 \centering
 \includegraphics[width=10cm]{figs/chapt-7/sine1.JPG}
-\caption Example showing how 2 waves combine to form a more complex wave (credit:cyberphysics.co.uk)
+\caption{Example showing how 2 waves combine to form a more complex wave (credit:cyberphysics.co.uk)}
 \end{figure}
 
 \spec{recall that waves can be diffracted and that substantial diffraction occurs when the size of the gap or obstacle is comparable to the wavelength}


### PR DESCRIPTION
Placed braces around a caption, so that the command \caption accepts the whole caption, not just the first letter, as its argument.

-- Benedict Randall Shaw